### PR TITLE
Make CNCF logo relative to site root

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@
 {% block footer %}
 <footer>
     <p class="subtext">We are a Cloud Native Computing Foundation sandbox project.</p>
-    <p><a href="https://cncf.io"><img src="img/cncf-color-bg.svg" height="75px" alt="CNCF logo"></a></p>
+    <p><a href="https://cncf.io"><img src="{{ get_url(path='img/cncf-color-bg.svg') }}" height="75px" alt="CNCF logo"></a></p>
 <p class="subtext">
     bootc, originally created by Red Hat and donated to open source with ❤<br/>
     Copyright © bootc, a Series of LF Projects, LLC<br/>

--- a/themes/juice/templates/base.html
+++ b/themes/juice/templates/base.html
@@ -78,7 +78,7 @@
     {% block footer %}
     <footer>
         <p class="subtext">We are a Cloud Native Computing Foundation sandbox project.</p>
-        <p><a href="https://cncf.io"><img src="img/cncf-color-bg.svg" height="75px" alt="CNCF logo"></a></p>
+        <p><a href="https://cncf.io"><img src="{{ get_url(path='img/cncf-color-bg.svg') }}" height="75px" alt="CNCF logo"></a></p>
         <p class="subtext">
             bootc, originally created by Red Hat and donated to open source with ❤<br/>
             Copyright © bootc, a Series of LF Projects, LLC<br/>


### PR DESCRIPTION
Previously with it being page-relative, the logo would render on the
main page at '/' but would not work for nested pages such as
'/about/'.

I've updated both the "main" template and the juice template, although
it appears that only the juice template is actually used by the site.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
