### PR TITLE
Add server_fqdn for matrix badge

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
     </div>
     <div class="text-center" style="padding-top: 10px;">
         <a href="https://matrix.to/#/#bootc:fedoraproject.org">
-            <img src="https://img.shields.io/matrix/bootc%3Afedoraproject.org?label=%23bootc%3Afedoraproject.org&style=for-the-badge&logo=matrix">
+            <img src="https://img.shields.io/matrix/bootc%3Afedoraproject.org?server_fqdn=chat.fedoraproject.org&label=%23bootc%3Afedoraproject.org&style=for-the-badge&logo=matrix">
         </a>
         &nbsp;
         <a href="https://cloud-native.slack.com/archives/C08SKSQKG1L">


### PR DESCRIPTION
Without this the badge current says "NOT FOUND" with a scary
red/orange background.

After this, the badge says "GUESTS NOT ALLOWED" with a much less scary
gray background.  I think that's as good as it's going to get on the
Fedora matrix instance.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
