### PR TITLE
move meeting notes from hackmd.io to bootc-dev.github.io/news

### DIFF
--- a/content/news/2025-07-11-community-meeting.md
+++ b/content/news/2025-07-11-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-july-11-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 11 July 2025
 ### Attendees

--- a/content/news/2025-07-11-community-meeting.md
+++ b/content/news/2025-07-11-community-meeting.md
@@ -1,10 +1,11 @@
-+++
-title = "Bootc Community Meeting Notes - 11 July 2025"
-date = 2025-07-11
-slug = "2025-july-11-community-meeting"
-+++
+# bootc community meeting
 
-### Attendees:
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 11 July 2025
+### Attendees
 - Joseph Marrero Corchado (Red Hat, Inc.)
 - Colin Walters
 - Robert Sturla (Tesco Bank/Universal Blue)
@@ -17,7 +18,7 @@ slug = "2025-july-11-community-meeting"
 - Chris Kyrouac
 - Gursewak Mangat
 
-### Agenda:
+### Agenda
 - New release status: [bootc-dev/bootc#1390](https://github.com/bootc-dev/bootc/issues/1390)
     - folks agreed on this
 - [Laura] [KubeCon NA 2025](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) [Project Pavilion application](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/project-opportunities/#description-of-opportunities)
@@ -36,6 +37,6 @@ slug = "2025-july-11-community-meeting"
     - Motivated by combinatorial explosion of gnome|kde * nvidia|amd * surface|framework|lenovo
     - discussion of downsides of systemd-sysext as defined today, vs
 
-### TODO:
+### TODO
 * [x] Put project pavilion application
 * [x] Keep smaller, more focused meetings

--- a/content/news/2025-07-11-community-meeting.md
+++ b/content/news/2025-07-11-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 11 July 2025"
+date = 2025-07-11
+slug = "2025-july-11-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-07-18-community-meeting.md
+++ b/content/news/2025-07-18-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-july-18-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 18 July 2025
 ### Attendees

--- a/content/news/2025-07-18-community-meeting.md
+++ b/content/news/2025-07-18-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 18 July 2025"
+date = 2025-07-18
+slug = "2025-july-18-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-07-18-community-meeting.md
+++ b/content/news/2025-07-18-community-meeting.md
@@ -1,10 +1,11 @@
-+++
-title = "Bootc Community Meeting Notes - 18 July 2025"
-date = 2025-07-18
-slug = "2025-july-18-community-meeting"
-+++
+# bootc community meeting
 
-### Attendees:
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 18 July 2025
+### Attendees
 - Laura Santamaria (she/her; Red Hat)
 - Hristo Marinov
 - Fernando Lozano
@@ -17,7 +18,7 @@ slug = "2025-july-18-community-meeting"
 - Gursewak Mangat
 - John Eckersberg (Red Hat, Inc.)
 
-### Agenda:
+### Agenda
 - [Release 1.5.1](https://github.com/bootc-dev/bootc/pull/1422)
   - Thanks @robert!
 - [Laura] project pavilion update?
@@ -41,7 +42,7 @@ slug = "2025-july-18-community-meeting"
     - [Laura] gave overview from OSPO and the other container group discussion
   - [Colin] Will open a discussion
 
-### TODO:
+### TODO
 - [ ] Laura to explore adding logos to PR.
 - [ ] Laura to add GitHub Actions for publication
 - [ ] Look for info on domain handling for static site

--- a/content/news/2025-07-25-community-meeting.md
+++ b/content/news/2025-07-25-community-meeting.md
@@ -1,0 +1,51 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 25 July 2025
+### Attendees
+- Robert Sturla (Tesco Bank / Universal Blue)
+- Hristo Marinov
+- Ben Breard
+- Laura Santamaria (she/her)
+- Joseph Marrero Corchado (Red Hat, Inc.)
+- Colin Walters
+- Dusty Mabe
+- Mohan Shash
+- Gursewak Mangat
+
+### Agenda
+- {%preview https://github.com/bootc-dev/bootc/milestone/5 %}
+    - Anyone have anything else to add to the milestone?
+    - Added a couple
+- Info about contributing: {%preview https://developers.redhat.com/blog/2025/07/23/shape-future-linux-contribute-bootc-open-source-project %}
+- [Colin] Assigning/delegating issues
+    - Right now not auto-assigning reviews and issues. Worth starting to do?
+    - Bot to round-robin reviews?
+    - https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
+    - Thoughts, opinions, screaming fights?
+        - [Joseph] OpenShift repos have something automatic like this. Agree the custom stuff is heavy-handed for us.
+        - [Colin] Merge queue is a huge example of something that GitHub added that used to be custom for other projects
+        - [Colin] will take action item to set something up for this
+- [Laura] Website PR - build is technically running on my fork
+    - {%preview https://github.com/bootc-dev/bootc-dev.github.io/pull/3 %}
+    - https://nimbinatus.com/bootc-dev.github.io/ (except my domain stuff is messing with links)
+    - [Ben] Do we want to move the this week in bootc there?
+    - [Ben] What about https://containers.github.io/bootable/ ? Move it? Use it? Wipe it?
+        - [Colin] There's two things: Specs/standards vs how it works. People have asked for "what's the bootc spec?" would be good to add it somewhere... Probably don't squash them yet.
+        - Containers org has been catchall. Just transfer the repo into bootc-dev? Could explain the spec there.
+        - Worth linking or leave it separate?
+            - Maybe come back to it? Any strong opinions?
+            - [Mohan] Linking would be helpful. Website at bootc.dev that links to it will make it easier to find...
+    - [Colin] Let's land website and iterate from there
+- rollup of events/blogs/releases, picking back up BCTW?
+    - Duplicates news?
+    - If there are blog topics we need to write on, talk with Ben?
+
+### TODO
+- [ ] Colin - set up review round-robin bot
+- [ ] Laura - go fix the css links
+- [ ] Laura - cname setup
+- [ ] Laura - fix the double-workflow issue on the site

--- a/content/news/2025-07-25-community-meeting.md
+++ b/content/news/2025-07-25-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-july-25-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 25 July 2025
 ### Attendees

--- a/content/news/2025-07-25-community-meeting.md
+++ b/content/news/2025-07-25-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 25 July 2025"
+date = 2025-07-25
+slug = "2025-july-25-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-08-01-community-meeting.md
+++ b/content/news/2025-08-01-community-meeting.md
@@ -1,0 +1,27 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 1 Aug 2025
+### Attendees:
+- Colin Walters
+- Mohan Shash
+- Jonathan Lebon
+- Robert Sturla
+
+### Agenda
+- bootloaders and composefs?
+  - Robert may look at WIP for detecting images without bootupd and defaulting to systemd-boot
+  - https://github.com/bootc-dev/bootc/issues/806#issuecomment-3145079372
+- composefs
+  - Live working session later 1:30pm EST
+  - future composefs will not require reprovisioning
+  - Discussion of https://github.com/bootc-dev/bootc/pull/1471
+- coreos transitioning to bootc
+  - https://github.com/bootc-dev/bootc/issues/1441
+  - https://github.com/coreos/rpm-ostree/issues/4994
+  - https://github.com/bootc-dev/bootc/issues/1320
+  - https://github.com/bootc-dev/bootc/issues?q=state%3Aopen%20label%3A%22area%2Fcoreos-alignment%22
+  - dnf discussion

--- a/content/news/2025-08-01-community-meeting.md
+++ b/content/news/2025-08-01-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-aug-01-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 1 Aug 2025
 ### Attendees:

--- a/content/news/2025-08-01-community-meeting.md
+++ b/content/news/2025-08-01-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 01 Aug 2025"
+date = 2025-08-01
+slug = "2025-aug-01-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-08-08-community-meeting.md
+++ b/content/news/2025-08-08-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 08 Aug 2025"
+date = 2025-08-08
+slug = "2025-aug-08-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-08-08-community-meeting.md
+++ b/content/news/2025-08-08-community-meeting.md
@@ -1,0 +1,47 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 8 Aug 2025
+### Attendees
+- Robert Sturla (Tesco Bank / Universal Blue)
+- Hristo Marinov
+- Laura Santamaria (she/her; Red Hat)
+- Colin Walters
+- Joseph Marrero Corchado (Red Hat)
+- John Eckersberg (Red Hat, Inc.)
+- Chris Kyrouac
+- Dusty Mabe (he/him; Red Hat)
+- Gursewak Mangat
+- Jonathan Lebon
+- Sean Thrailkill
+- afterstory
+
+### Agenda
+- [Colin] More on composefs {%preview https://github.com/bootc-dev/bootc/issues/1498 %}
+    -  [Colin] Clientside reworking on how we store files. Then there's the build side to this whole thing. What's the user experience look like for creating an image
+    -  [Colin] Recap from previous meeting
+    -  [Colin] Fatal flaw of binary copying into host
+    -  [Colin] Issue is about build side
+    -  [Colin] Logistically simplest - containers build however you want, bootc cleans up, then user provide secure boot key
+    -  [Jonathan] Not following super closely, but feels like we're starting with the hard case. Any work around non-sealed composefs builds today? Does it work?
+        -  [Colin] Yes, kinda. "It Depends":tm: Gets into whole problem around how we transition installs. Doesn't need to be sealed, but only target UKIs to start. We get into mechanical issue of default Fedora base images aren't set up for UKI. ostree backend does not really support UKIs (at least not with UEFI). Yes, it definitely will support nonsealed systems. Assuming we want to run this tool on your container images anyway.
+        -  [Jonathan] Need to make sure that, when designing, want to consider how migrate existing systems, and how will work with unsealed systems. Sealed case may be a specialized thing in beginning. May affect design; overconstrain.
+        - [Colin] We will definitely support transitioning existing systems. In end, can always boot without secure boot, too.
+        - [Colin] not committing to anything; this is still experimental. Nothing stops us from allowing flow within Dockerfiles, too.
+    - [John] Haven't really explored it a whole lot. May change, and likely will hit many walls. Just wanted to start discussion. Please feel free to comment in issue! Help find flaws in plan :)
+    - [Colin] Want people to feel free to ask questions in this meeting! Don't be afraid to ask for clarity, ask to help contribute.
+- [Sean] Recently gave talk at Flock about state of bootc! Big fan, want to get involved. We've shifted away from how installation process used to work. Used to be build your artifacts, now transitioning to replace the existing install, especially in more cloud-centric areas. What was the impetus for the change in direction?
+    - [Colin] Very interested. Wouldn't say it's backing away. We know we have to support a flow where you have a container image, then allow to turn into ISO or raw disk file. Too many use cases for that to give it up (e.g., edge, IOT devices, want to preconfigure before ship). We have to support that. Tension is in some clouds, managing disk images kinda stinks. Esp. AWS, as an example. There's two different worlds, and we do need to do both.
+    - [Dusty] bootc image builder supports uploading AMI for AWS, but usually you have to figure that part out on your own. Now also options to boot and then replace. That's more of a "let's remove the extra step from the user's responsibility, allow for existing thing that can be paved over." Might make it easier.
+    - [Sean] Makes sense. Sounds like this is to make it simpler for the user; pave over idea makes sense for the user.
+    - [Dusty] idea is they already have podman, which can run the container than can then pave your system. Bootc is on engineer's device. Positives and negatives. Positive: You start with whatever image for OS is on your cloud, and then you have to rebase that instance to your container. Negative: Feels like there's a new cloud that pops up everyday. Feels like we're constantly chasing the ball. Better experience is wherever you are is a starting point. So this allows to start from *something* you can start from. Doesn't even have to be EL-based. Can be Ubuntu. Can get to success without having to create your own disk image.
+    - [Colin] Not an installer in the partitioning sense. We want to make it easy/happy path for someone making own OS or distro - closer you can get to OS is container, then the installer area can be smaller. Bootc doesn't know how big you want your partition to be, for example, but if you can use whatever installer to install your containerized OS, then you're in a better space. Freya Labs also investigating bootc, called readymade.
+    - [Laura] I'll see if I can find them. (chat noted that they're in the universal blue discord)
+- [Jonathan] Choice of filesystem in container image and possibility of putting the choice of the filesystem in the image itself
+    - [Colin] Would like to support systemd-repart as part of MVP first, possibly able to support something like this later.
+- Lots of talk about new friends, inviting new friends, and timezone issues (we know this isn't great for Europeans and others.)
+- Discussion of recording meeting, general agreement we should probably record and post
+ - One option: Split 50%/50% recorded vs not, the advantage of this would be that the second half can be for "stupid questions" that people may not be comfortable having on the Internet Forever

--- a/content/news/2025-08-08-community-meeting.md
+++ b/content/news/2025-08-08-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-aug-08-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 8 Aug 2025
 ### Attendees

--- a/content/news/2025-08-15-community-meeting.md
+++ b/content/news/2025-08-15-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-aug-15-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 15 Aug 2025
 ### Attendees

--- a/content/news/2025-08-15-community-meeting.md
+++ b/content/news/2025-08-15-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 15 Aug 2025"
+date = 2025-08-15
+slug = "2025-aug-15-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-08-15-community-meeting.md
+++ b/content/news/2025-08-15-community-meeting.md
@@ -1,0 +1,66 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 15 Aug 2025
+### Attendees
+- Colin Walters
+- John Eckersberg (Red Hat, Inc.)
+- Joseph Marrero Corchado (Red Hat, Inc.)
+- Mohan Shash
+- Michael Fox
+- Preethi Thomas
+- Robert Sturla (Tesco Bank)
+- Hristo Marinov
+- Laura Santamaria (she/her; Red Hat)
+- Johnathan Lebon
+- Sean Thrailkill
+- Gursewak Mangat
+- Dusty
+- Michael Tunnell (Framework)
+- AfterStory
+- Jorge Castro (CNCF/Linux Foundation)
+
+### Agenda
+- [Jonathan] bootc plugin system
+    - [Jonathan] What do we want the UX to be like? Two high-level approaches: dnf drives bootc, or bootc drives dnf. This is currently Fedora focused, but implementation details is not Fedora focused. If dnf does persistent package layering, goal should still be bootc upgrade and bootc status work and that's the user. For that to work, bootc and dnf need to work together, hence plugin system. How do we have bootc communicate with other applications (this is where it's non-Fedora centric). Logic shouldn't likely live in bootc, right? What's the plugin API look like?
+    - [Colin] Wasn't there an issue about this?
+    - [Jonathan] context the first time was originally rpmtree
+        - {%preview https://github.com/bootc-dev/bootc/issues/337 %}
+    - [Colin] Complicated. Think about progress reporting, especially as GUI. We want a progress bar, coherent representation of what's happening. Want accurate change detection. Want things visually simple to understand for user. If bootc forks off other binary, punt the issue of how representation of state works. Inclination is to punt to the tool; make it the job of the higher-level tool.
+    - [Jonathan] Going to server model, you would do dnf status, for example, and dnf upgrade?
+    - [Colin] Yes, can't avoid the tools and need to know about both in some cases. Could cover a lot of cases if we taught the package managers how to manage a sysext that they own locally. There's already a lot of tooling to introspect sysext.
+        - {%preview https://github.com/rpm-software-management/dnf5/issues/1731 %}
+    - [Dusty] if we make it generic (e.g., local layering), local packages is one plugin that's really important. Being able to add a package that's not in the thing that you're following is extremely convenient. In most cases, there's a package manager tool that you could make plugins, and tool itself could learn how to do thing in sysext, then bootc doesn't have to care (or maybe it does?). How many things do people have to touch to upgrade system? What's the better user experience? If you step away from package managers/systems, then that's where it gets iffy. Might make more sense to make bootc the one that controls that instead of having dracut try to call bootc. Might be better bootc managing as plugin way.
+        - Bootc notices update, grabs it, then pipeline - output is input to next step. Output of pipeline is from plugins. Idea is more that mutiple plugins can stack. Or can combine to multistage build (yay pipelines).
+    - [Colin] Wary of adding more complexity to bootc right now. Issues in place, example: We don't have unified storage (podman build/docker build is super awkward at the moment). There's prepwork we need to add. Someone else might need to own that task. Still problem of non-package content.
+    - [Sean] Inclined to agree. Keep bootc simple; teaching other tech to know how to layer versus trying to edit the image that is actually booted (and security implications for that).
+    - [Dusty] Use case thinking about is in a scenario where someone is autoupdating their system. e.g., normally they don't touch it. How can they keep the things that they have done to keep everything up to date? That's why like the plugin model. Then other things get updated alongside the upgrade that happens (e.g., the user who ran a command years ago and doesn't remember that command). How to keep config that was made up to date, etc. Have same problem today in ostree world where there's package layering, e.g., orphaned packages.
+    - [Jonathan] Package layering is a big one as it's a common want. When you boot up a bootc system, you use bootc to manage it, from point on to add package, then you stop touching bootc and have to know other tools. Introduces split brain. Is bootc an implementation detail of dnf? Feels awkward. Would be better that bootc knows the state of the system. Make bootc the entrypoint to managing your system.
+    - [Dusty] Would be nice if someone runs bootc status and copy-paste to issue filed, then shows full system. Would be helpful to have single pane of glass.
+    - [Laura/Colin] Let's move to an issue for more discussion. Jonathan to make the issue.
+- [Mohan] Follow up - when is the site going live: https://github.com/bootc-dev/bootc-dev.github.io? 
+    - [Laura] The site is live at https://bootc-dev.github.io, but are you asking about moving it to bootc.dev?
+        - [Mohan] Thanks, I wasn't aware that it was live already :-)
+- [Robert] what info should we get from users who hit this? {%preview https://github.com/ostreedev/ostree/issues/2283 %}
+    - [Robert] One of the most annoying bugs we face. No easy way to resolve when it happens, no reproducable steps. What can we do to help debug?
+    - [Colin] Don't know offhand. Could ask folks to share journals and get more logs. AI version churning on that.
+    - [Hristo, in chat] {%preview https://discussion.fedoraproject.org/t/silverblue-wont-boot-after-forced-shutdown-searching-for-ways-to-recover-it/155432 %}
+    - [Jonathan] Catchall issue. Symptoms look the same, but not same root cause. When initially filed this, cause was people doing reinstalls and they had old install on disk one but new on disk 2, then partitions got the bootloader confused. Another way this can happen is if something during shutdown procedure didn't get transactionally logged. Really hard to debug. Having steps to reproduce is really key.
+    - [Michael, in chat] {%preview https://github.com/ublue-os/bluefin-lts/issues/658 %}
+        - "Apparently the bluefin is related to btrfs + bootc"
+    - [Hristo] Spent a long amount of time trying to reproduce on baremetal machine; in all states, shutdown machine with power switch. Cannot reproduce this issue. Mentioned this in the Fedora discussion thread. But needs that reproduction details. Seems very difficult to reproduce.
+    - [Laura] Can we make a big issue to collect everything?
+    - [Colin] Sure?
+    - [Jorge] Everyone is blaming btrfs.
+    - [Dusty] Also discussed on LinuxUnplugged. Seems to only be on 16.3
+    - **ACTION**: Let's make the catchall here: {%preview https://github.com/ostreedev/ostree/issues/2283 %}
+- ~~[Robert] Systemd Boot - can we start with a hidden flag passed from bootc? https://github.com/coreos/bootupd/pull/978~~ Can move to discussion in the PR
+    - [Laura] Thank you! Please bring it back up again next week if the discussion needs to be live!
+
+### TODO:
+- [ ] Jonathan to make an issue for the plugin discussion to continue offline.
+- [ ] Laura to find out how to get the bootc.dev CNAME setup
+- [ ] All to drop catchall for the persistent bug in the issue

--- a/content/news/2025-08-22-community-meeting.md
+++ b/content/news/2025-08-22-community-meeting.md
@@ -1,0 +1,8 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 22 Aug 2025
+Canceled as many folks have PTO. Enjoy a day off!

--- a/content/news/2025-08-22-community-meeting.md
+++ b/content/news/2025-08-22-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 22 Aug 2025"
+date = 2025-08-22
+slug = "2025-aug-22-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-08-22-community-meeting.md
+++ b/content/news/2025-08-22-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-aug-22-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 22 Aug 2025
 Canceled as many folks have PTO. Enjoy a day off!

--- a/content/news/2025-08-29-community-meeting.md
+++ b/content/news/2025-08-29-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 29 Aug 2025"
+date = 2025-08-29
+slug = "2025-aug-29-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
@@ -5,7 +11,6 @@
 Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
 
 ## 29 Aug 2025
-
 ### Attendees
 - Laura Santamaria (Red Hat)
 - Joseph Marrero Corchado (Red Hat, Inc.)

--- a/content/news/2025-08-29-community-meeting.md
+++ b/content/news/2025-08-29-community-meeting.md
@@ -1,0 +1,46 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 29 Aug 2025
+
+### Attendees
+- Laura Santamaria (Red Hat)
+- Joseph Marrero Corchado (Red Hat, Inc.)
+- Colin Walters
+- Preethi Thomas
+- John Eckersberg (Red Hat, Inc.)
+- Robert Sturla (Tesco Bank / Universal Blue)
+- Hristo Marinov
+- Dusty Mabe
+- Ben Breard
+- Jonathan Lebon
+- Timothée Ravier
+
+### Agenda
+- Dynamic bootloader detection in bootupd {%preview https://github.com/coreos/bootupd/pull/978 %}
+    - Robert gave a review of the PR
+    - Discussion? _(Sorry, coming in during the middle of the discussion... - LAS)_
+        - Grub vs systemd boot
+        - **Decision:** Robert will default to grub if found, but will use systemd boot if it's not there
+        - composefs/bootc meeting - reach out to join. Dealing with conflict/opening branch
+- Open floor time
+    - [Ben] got a request to help migrate from existing installs into bootc system. Would you be able to pull package database from system? Maybe scrape etc/? Sounds like endless edge cases... Thoughts?
+        - [Colin] Someone in upstream Slack is doing this and has it mostly working for their prod systems. SELinux issue. Key thing that would be really helpful is preserving existing bootloader entries and making it non-destructive. Would immensely aid testing. Totally doable.
+        - [Ben] Wouldn't you need to eventually blow away the existing loaders?
+        - [Colin] Yeah, garbage collection is a thing. We can blow away containers but leave everything else. Didn't want to get in the business of blowing away data. Not hard to do cleanup as you wish (systemd container in sysroot, then remove things). If data partitions, everything gets easier.
+    - [Jonathan] Actually thought we were talking about something different. config starting point.
+        - [Ben] Should be easy to scrape RPMs and modify base image with diff out and add into containerfile. Only handling package side.
+        - [Jonathan] Could copy to containerfile then etc to preserve those?
+        - [Colin] [thread](https://cloud-native.slack.com/archives/C08SKSQKG1L/p1756205380188269?thread_ts=1755600945.963309&cid=C08SKSQKG1L) for person doing install is in CNCF Slack.
+- Procedural note: Laura won't be here next two weeks, will be traveling and also representing bootc at DevConf.us
+- Meta: Notes about who takes notes! We'll try to assign someone to do this in each meeting on a rotating basis
+- conferences - also KubeCon is coming up! Laura is talking about sharing a schedule for the booth.
+- Discussion of swag: ideas? 3d prints, t-shirts, (cat ears?), *not* socks; avoid requiring sizes? RaspberryPis pre-loaded?
+  - pre-flashed SD cards for RPi (cheaper)
+  - Goal: something someone can try right away
+- KubeCon sync up for OS folks
+- #wg-sp-os holds Flatcar folks
+- Looks like https://github.com/cncf/toc/blob/main/tags/tag-workloads-foundation/README.md technically would have bootc in scope

--- a/content/news/2025-08-29-community-meeting.md
+++ b/content/news/2025-08-29-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-aug-29-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 29 Aug 2025
 ### Attendees

--- a/content/news/2025-09-05-community-meeting.md
+++ b/content/news/2025-09-05-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-sep-05-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 5 Sept 2025
 ### Attendees

--- a/content/news/2025-09-05-community-meeting.md
+++ b/content/news/2025-09-05-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 05 Sep 2025"
+date = 2025-09-05
+slug = "2025-sep-05-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-09-05-community-meeting.md
+++ b/content/news/2025-09-05-community-meeting.md
@@ -1,0 +1,21 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 5 Sept 2025
+### Attendees
+- Mohan Shash (RH)
+- Colin Walters (RH)
+- Robert Strula (Tesco Bank / Universal Blue)
+- John Eckersberg (RH)
+- Jonathan Lebon (RH)
+
+### Agenda
+- https://github.com/containers/canon-json-rs/issues/7#issuecomment-3256310192 etc. No one disagreed with this move
+- https://github.com/bootc-dev/infra/issues/18
+- jlebon: In FCOS hitting signing issues
+    - https://github.com/coreos/fedora-coreos-tracker/issues/1969#issuecomment-3251151820
+- Maybe demo/discuss https://github.com/cgwalters/bootc-kit/commit/625b8be147df2fc196ac1e4bdb32d3657df90992
+- Discussion of arch base images!

--- a/content/news/2025-09-12-community-meeting.md
+++ b/content/news/2025-09-12-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-sep-12-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 12 Sept 2025
 ### Attendees

--- a/content/news/2025-09-12-community-meeting.md
+++ b/content/news/2025-09-12-community-meeting.md
@@ -1,0 +1,28 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 12 Sept 2025
+### Attendees
+- Robert Strula (Tesco Bank* / Universal Blue)
+- Mohan Shash (RH)
+- Jonathan Lebon (RH)
+- Preethi Thomas (RH)
+- Michael Fox (RH)
+- Chris Kyrouac (RH)
+- Hristo Marinov
+- Tulip Blossom
+- Gursewak Mangat (RH)
+- Pragyan Poudyal (RH)
+- John Eckersberg (RH)
+- Joseph Marrero (RH)
+- Dusty Mabe (RH)
+
+### Agenda
+- bootc-kit will become bcvk, will publish soon
+- Live merge of [Composefs backend PR](https://github.com/bootc-dev/bootc/pull/1444) :tada:
+- https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1174
+- https://discussion.fedoraproject.org/t/native-oci-storage-for-dnf/163534
+- Discussion of old ostree and composefs in OpenShift

--- a/content/news/2025-09-12-community-meeting.md
+++ b/content/news/2025-09-12-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 12 Sep 2025"
+date = 2025-09-12
+slug = "2025-sep-12-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-09-18-community-meeting.md
+++ b/content/news/2025-09-18-community-meeting.md
@@ -1,0 +1,15 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 18 Sep 2025
+- [walters] Move composefs into bootc-dev?
+  - CNCF donation, should we treat like seperate project (eg: Podman)
+  - Composefs will come with bootc, it's not standalone.
+  - ostree being reduced, so we should do it? bootc take over the responsibility
+  - AI: colin to file github issues for discussion
+- [walters] bcvk! https://github.com/cgwalters/bcvk
+- [jeckersb] composefs community meeting moving to public
+

--- a/content/news/2025-09-18-community-meeting.md
+++ b/content/news/2025-09-18-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-sep-18-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 18 Sep 2025
 - [walters] Move composefs into bootc-dev?

--- a/content/news/2025-09-18-community-meeting.md
+++ b/content/news/2025-09-18-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 18 Sep 2025"
+date = 2025-09-18
+slug = "2025-sep-18-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-09-26-community-meeting.md
+++ b/content/news/2025-09-26-community-meeting.md
@@ -1,0 +1,49 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 26 Sept 2025
+### Attendees
+- Laura Santamaria (she/her; Red Hat)
+- Dusty Mabe (he/him; Red Hat)
+- Sean Thrailkill
+- Robert Sturla (Tesco Bank)
+- Jonathan Lebon (Red Hat)
+- Tulip Blossom (Chainguard)
+- Joseph Marrero (Red Hat)
+- Mohan Shash (RH)
+- Preethi Thomas
+- Hristo Marinov
+- Colin Walters
+
+### Agenda
+- [Mohan] Anything interesting from the conference - DevConf.us
+    - [Laura] Bootc discussions - nothing significant for the community
+- [Sean] Sean is doing a presentation on bootc - Texas Linux Fest
+    - Laura to send bootc stickers for Sean
+- All things Open - Conference in raleigh
+    - Is bootc represented? not sure
+    - Laura will look into this
+- [Sean and Tulip] New KDE thing. They use mkosi + systemd-sysupdate, there is a WIP arch-bootc based KDE linux spin. Actually its from one of the KDE Linux devs. He forked arch-bootc from bootcrew
+    - {%preview https://github.com/silverhadch/arch-bootc-kde %}
+- [Colin] New development workflow
+    - Always looking for feedback
+    - {%preview https://github.com/bootc-dev/bootc/issues/1635 %}
+    - {%preview https://github.com/bootc-dev/bootc/pull/1638 %}
+- jlebon: Working on signing
+    - Working on adding necessary stuff to container libraries to make that nicer
+    - {%preview https://github.com/containers/container-libs/pull/355 %}
+    - {%preview https://github.com/containers/skopeo/pull/2714 %}
+    - {%preview https://github.com/containers/skopeo/issues/1829 %}
+        - Skopeo ticket locked - **Blocker**
+        - Needs unlocked to get unblocked for people to commment
+        - Learned a lot recently when switching from ostree signing to OSCI signing.
+- [Colin] Outstanding PRs?
+    - Anyone else want to grab any? 1645 would be great for someone to pickup.
+        - {%preview https://github.com/bootc-dev/bootc/pull/1645 %}
+
+### TODO
+- [ ] Someone needs to unlock the Skopeo ticket - Ping Lokesh
+

--- a/content/news/2025-09-26-community-meeting.md
+++ b/content/news/2025-09-26-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-sep-26-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 26 Sept 2025
 ### Attendees

--- a/content/news/2025-09-26-community-meeting.md
+++ b/content/news/2025-09-26-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 26 Sep 2025"
+date = 2025-09-26
+slug = "2025-sep-26-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-03-community-meeting.md
+++ b/content/news/2025-10-03-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 03 Oct 2025"
+date = 2025-10-03
+slug = "2025-oct-03-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-03-community-meeting.md
+++ b/content/news/2025-10-03-community-meeting.md
@@ -1,0 +1,65 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 3 Oct 2025
+### Attendees
+- Robert Sturla (Tesco Bank)
+- Laura Santamaria (Red Hat; she/her)
+- AfterStory
+- Tulip Blossom (Chainguard; she/her)
+- Colin Walters
+- Mohan Shash
+- Hristo Marinov
+- John Eckersberg (Red Hat)
+- Gursewak Mangat
+- Chris Kyrouac
+- Jonathan Lebon
+- Dusty Mabe (he/him; Red Hat)
+
+### Agenda
+- Laura: Intros, note use of CNCF code of conduct.
+- [Mohan] Demo videos to be uploaded in CNCF channel. Goal: Re-use the demos, reference in docs etc..
+    - Record and share your demos. Laura is helping us with setting up the access to post the videos on CNCF channels
+    - [Laura] Ticket is in (link?), who is a maintainer and wants access?
+        - Note this has to be someone who is a maintainer: {%preview https://github.com/bootc-dev/bootc/blob/main/MAINTAINERS.md %}
+        - [Colin] can we all just do it? [Laura] Sure, but remember you're going to be responsible :)
+        - [Colin] How about we go over videos in this meeting? (or in slack?) Basically just a mechanism to review things
+        - Decision: All have access, maybe a review call after community meeting.
+- [Robert] Official E2E examples/templates for different use-cases?
+    - https://cloud-native.slack.com/archives/C08SKSQKG1L/p1759441407750519
+    - Currently have [Fedora Bootc examples](https://gitlab.com/fedora/bootc/examples), but these are only the Containerfile definitions.
+    - Jorge suggested adopting the [Universal Blue Image Template](https://github.com/ublue-os/image-template).
+    - Other enterprise-ready examples could include workflows for testing with [bcvk](https://github.com/bootc-dev/bcvk) and [test.thing](https://codeberg.org/lis/test.thing) and additional tooling for security gating and compliance requirements.
+    - [Colin] Base images templates make total sense!
+    - [Colin] {%preview https://github.com/ublue-os/image-template/blob/main/Justfile %}
+    - [Dusty] Do they build just containers or boot images?
+        - [Robert] Good to have examples of both of them.
+    - [Laura] What about a cookie cutter and then an awesomelist?
+        - Another tool that is used to build disk images (I think in SUSE and some in Fedora) is kiwi, so if support was added there it would be a good one to add to the awesomelist.
+    - [Afterstory in chat] I remember a chat with wanting to move/have a equivalent uBlue image template on bootc org repo
+    - [Tulip in chat] I think it would be interesting to have integration with the ArtifactHub (https://artifacthub.io/) project for discoverability
+    - {%preview https://github.com/topics/bootc %}
+    - [Robert] What about a reference image for enterprise? or out of scope?
+        - [Colin] Related to enterprise - disconnected environments. Would make total sense though. There's a lot in this space ([flight control project](https://github.com/flightctl/flightctl/) as one example). Some people want an opinionated system that pulls in bootc as one part; that's an interesting one to consider for a reference image/awesomelist.
+        - [Robert] Yeah, flightctl does safe rollout and automated way, so would be good to show how to implement flightctl with bootc
+- [Colin] composefs status!
+    - Making some progress!
+    - Would love to have people come work on it together
+    - Multistage image for base image
+    - Cleaning up the build system stuff and hoping to land the testing and things there. John is working on the build side.
+    - Anyone welcome to do live chat system!
+
+### Shoutouts
+- Sean is doing a workshop at Texas Linux Fest today!
+
+### TODO
+- [ ] Laura to send replies to Riaan re: channel maintainers
+- [ ] Laura to connect with Mohan re [community manager role](https://github.com/bootc-dev/bootc/blob/main/MAINTAINERS.md#community-managers)
+- [ ] Open ticket for awesome list
+- [ ] Make the repo for awesomelist
+- [ ] Kick off templates
+- [ ] If you want to work on composefs, chat in the bootc-dev channel and do some live coding
+

--- a/content/news/2025-10-03-community-meeting.md
+++ b/content/news/2025-10-03-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-oct-03-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 3 Oct 2025
 ### Attendees
@@ -63,7 +63,7 @@ Feel free to add yourself to the attendee list and to add to the agenda! This is
 
 ### TODO
 - [ ] Laura to send replies to Riaan re: channel maintainers
-- [ ] Laura to connect with Mohan re [community manager role](https://github.com/bootc-dev/bootc/blob/main/MAINTAINERS.md#community-managers)
+- [ ] Laura to connect with Mohan re [community manager role](https://github.com/bootc-dev/bootc/blob/main/MAINTAINERS.md#user-content-community-managers)
 - [ ] Open ticket for awesome list
 - [ ] Make the repo for awesomelist
 - [ ] Kick off templates

--- a/content/news/2025-10-10-community-meeting.md
+++ b/content/news/2025-10-10-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-oct-10-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 10 Oct 2025
 ### Attendees

--- a/content/news/2025-10-10-community-meeting.md
+++ b/content/news/2025-10-10-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 10 Oct 2025"
+date = 2025-10-10
+slug = "2025-oct-10-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-10-community-meeting.md
+++ b/content/news/2025-10-10-community-meeting.md
@@ -1,0 +1,33 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 10 Oct 2025
+### Attendees
+- Tulip Blossom
+- Sean Thrailkill
+- Robert Strula
+- John Eckersberg
+- Preethi Thomas
+- Prasanth Baskar
+- Hristo Marinov
+- Pragyan Poudyal
+- Dusty Mabe
+- Joseph Marrero
+
+### Agenda
+- Sean to meet with CIQ to discuss Rocky Linux Bootc images
+  - slack thread - https://cloud-native.slack.com/archives/C08SKSQKG1L/p1759947000990329
+- (Robert - no mic) - Do you still have the weekly composefs backend meetings, and is the intention to make them public?
+    - Yes! We missed a week because of some group meetings
+    - We'll try to make them public next week! (Thursdays at 08:30 EDT)
+- [Discussion forum post about continuing the bootc initiative in Fedora](https://discussion.fedoraproject.org/t/renewing-the-fedora-bootc-now-image-mode-initiative/167131/27)
+    - Fedora specific: [creating disk images proposal](https://gitlab.com/fedora/bootc/tracker/-/issues/77)
+- ["soft" or "light" bootc proposal](https://github.com/bootc-dev/bootc/issues/1668) - just raising awareness for comment/feedback!
+
+### Shoutouts
+- Texas Linux Fest Workshop was very successful!
+    - https://2025.texaslinuxfest.org/talks/create-your-own-bootable-container/
+    - https://cloud-native.slack.com/archives/C08SKSQKG1L/p1759504991874539

--- a/content/news/2025-10-17-community-meeting.md
+++ b/content/news/2025-10-17-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 17 Oct 2025"
+date = 2025-10-17
+slug = "2025-oct-17-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-17-community-meeting.md
+++ b/content/news/2025-10-17-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-oct-17-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 17 Oct 2025
 ### Attendees

--- a/content/news/2025-10-17-community-meeting.md
+++ b/content/news/2025-10-17-community-meeting.md
@@ -1,0 +1,46 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 17 Oct 2025
+### Attendees
+- Mohan Shash (RH)
+- Robert Sturla (RH - on Monday :tada:) :heart:
+- Joseph Marrero (RH)
+- Jorge Castro (CNCF)
+- Laura Santamaria (she/her; Red Hat)
+- Colin Walters
+- John Eckersberg (Red Hat, Inc.)
+- Pragyan Poudyal
+- Gursewak Mangat
+- Jonathan Lebon
+- Dusty Mabe
+
+### Agenda
+ - composefs progressing: {%preview https://github.com/bootc-dev/bootc/pull/1662 %} merged!
+    - {%preview https://github.com/coreos/bootupd/pull/978#issuecomment-3411377999 %}
+    - [Jorge] Is anyone doing systemd-boot on baremetal? I want a screenshot. :D
+    - [Colin] Yes! Surprise :D
+    - [Colin] One of the initial targets is custom sealed images. So you have your own CKI signed image with own cert, then can provision env with cert chain.
+    - Lots of folks want to use machine owner keys flow (requires shim); we'll likely enhance Robert's patch to allow support, which will eventually allow secureboot to shim to secure owner keys. But if want bootc on baremetal without secureboot, you can do that now.
+    - [Robert] Are you looking for testing stuff?
+        - [Colin] ostree doesn't support UKIs yet. TL;DR: There is support for using GRUB and systemd backend using UKIs. In theory, things will work with things. But! not targeting the ostree backend right now for systemd-boot. Do you want that?
+        - [Robert] Went off git main build, so where would testing be the most wanted? Just trying to figure out where testing is needed.
+        - [Jorge] - we should tell more people about the git copr for bootc, I only discovered it exists today!
+        - [Colin] bootupd is a soft requirement, so asking for people to try it out. Secondary, getting closer to composefs backend as daily driver
+        - [John] Gets us close to having other distros as part of upstream CI as well. Wanting to do that so we don't break anyone else :)
+        - [Jorge] Updates not working yet on other distros. Their Discord is poppin though!
+        - [Jorge] SUSE did a talk on some kind of weird btrfs snapshots? May be using Podman backend.
+ - [Mohan] Demo - YouTube access to CNCF is approved for all the maintainers
+     - We have access!
+     - Laura and Mohan to connect on Monday to establish how to do this.
+     - So! If you are working on anything, make a video! Bring it to this call, and we'll review as a groups.
+     - Laura can advise if you want to do it
+     - [Colin] What's the quality bar?
+     - Laura: offers to help mentor folks!
+     - Laura: Lots of advice on setup: avoid it being a noisy environment
+ - [Jorge] How's soft reboot coming along?
+     - Robert: Initial soft reboot support in Bootc 1.7.0 - Doesn't work with LUKS-encrypted drives (using BTRFS/created with Anaconda?)
+      - Joseph will produce a blog soonish :-)

--- a/content/news/2025-10-24-community-meeting.md
+++ b/content/news/2025-10-24-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-oct-24-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 24 Oct 2025
 ### Attendees

--- a/content/news/2025-10-24-community-meeting.md
+++ b/content/news/2025-10-24-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 24 Oct 2025"
+date = 2025-10-24
+slug = "2025-oct-24-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-24-community-meeting.md
+++ b/content/news/2025-10-24-community-meeting.md
@@ -1,0 +1,53 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 24 Oct 2025
+### Attendees
+- Colin Walters
+- Robert Sturla (Red Hat)
+- Sean Thrailkill
+- Hristo Marinov
+- Laura Santamaria (Red Hat; she/her)
+- Preethi Thomas
+- Mohan Shash (RH)
+
+### Agenda
+- {%preview https://github.com/bootc-dev/bcvk/pull/86 %}
+    - Looking for feedback
+    - Improving iteration speed for testing for humans and AI (autonomous changes). Also dealing with technical debt.
+    - Demo!
+        - This is inspired a bit by Vagrant. There's a new project verb that has a lot of syntactic sugar for bcvk. (Note that this is mostly generated via an AI agent, but Colin reviews all things before committing.)
+        - The idea is in other libvirt verbs, you have to give it to specific VMs
+        - This one scopes to specific repo
+        - Refers to locally built bootc image
+        - Initializes project, allows you to find local VM; caches disc images (cached base image corresponding to base image built; or could just build)
+        - The sugar is autobind mount the host container storage
+        - Now, when ssh in, you can -a to autoupdate
+        - If rebuild on host the container image (build new bootc image from code from repo), then bcvk project ssh -a, then inner VM fetch just new layers and will allow you to ssh in and try out new code
+    - [Sean] Awesome on how easy this is. Allows all kinds of users to do all kinds of cool stuff.
+    - [Colin] not just for devs, you can do this for things like tweaking firewall rules - iterating locally and then pushing to cloud or metal. CDK replaces podman-bootc. Trying also to wrap bib as well.
+    - [Colin] Several ways to do installs, but day2 stuff should all be the same. So if wrap Anaconda, then can do the local runs and libvirt VM with all the sugar added.
+    - [Sean] Why start developing this tool versus updating podman-bootc?
+        - [Colin] Podman-bootc had some technical debt. Fundamental redesign was because of requiring podman machine on Linux, which causes cascading problem.
+        - [Colin] There's some vendoring that hops us on the CVE train
+        - [Colin] So instead, this just forks Podman and Rust things, so no bundled co-libraries to deal with layered CVEs
+- [Mohan] Working on first video edits. Hopefully will have a cool new video on this wink wink
+- [Robert] Wants to enforce bootc switch globally config option for universal blue.
+    - [Colin] {%preview https://github.com/containers/container-libs/pull/355 %}
+    - [Colin] Jonathan was working on this for CoreOS. Was this the same thing?
+    - [Robert] Haven't seen this yet, but looks similar on first quick look
+    - [Colin] This links to Skopeo issue 309, which is this thing. Plumb this through into Skopeo proxy then plumb into bootc. Want to align how bootc feels and works to other container runtimes feel and work, so should enforce sigs on logically bound apps and stuff, too. Maybe once library side of this finally merges, then we should talk about whether this is a CLI flag or global, right?
+    - [Robert] Would be good to have it be global. Secure by default design. Currently no method for global config save the thing from ostree.
+    - [Colin] We should be posting the same policy json. Just drop out insecureAcceptAnything default should do it.
+    - [Robert] This should affect the host image and the podman image right?
+    - [Colin] Yup, the whole family of tools
+    - [Robert] Not everyone signs...
+    - [Colin] This came up in a different context (may need docs). Short answer no. If run bootc as systemd unit, could easily use bind paths. Not the most beautiful thing and would like first class support, but that's the status quo on it right now. Might be an env var to change where policy.json is searched for. Agree on usecase, though. Want to get that in :)
+
+### Shoutouts
+- Shoutout to Robert for joining Red Hat!
+- Thank you to Jonathan Dieter and Eli from CIQ for meeting with Sean and getting bootc images out for Rocky! [Link](https://git.resf.org/sig_containers/rocky-bootc)
+    - Shoutout to Sean for having those meetings!

--- a/content/news/2025-10-31-community-meeting.md
+++ b/content/news/2025-10-31-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 31 Oct 2025"
+date = 2025-10-31
+slug = "2025-oct-31-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-10-31-community-meeting.md
+++ b/content/news/2025-10-31-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-oct-31-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 31 Oct 2025 (Happy Halloween! :jack_o_lantern: :ghost: :skull: )
 ### Attendees

--- a/content/news/2025-10-31-community-meeting.md
+++ b/content/news/2025-10-31-community-meeting.md
@@ -1,0 +1,54 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 31 Oct 2025 (Happy Halloween! :jack_o_lantern: :ghost: :skull: )
+### Attendees
+- Colin Walters
+- John Eckersberg
+- Mohan Shash (RH)
+- Laura Santamaria (I'm a teapot)
+- Robert Sturla (RH)
+- Jorge Castro (CNCF)
+- Tulip Blossom (Chainguard)
+- Joseph Marrero Corchado (RH)
+- AfterStory
+- Sean Thrailkill
+- Hristo Marinov
+- Gursewak Mangat
+- Preethi Thomas (RH)
+
+### Agenda
+- [name=Jorge] Who's going to kubecon? [Colin, Joseph, Laura, Jorge, ...]
+- [name=Jorge] Reference Architecture for bootc
+    - CNCF projects have a reference arch, usually published by end users. e.g., how Adobe uses Argo. {%preview https://architecture.cncf.io/ %}
+    - Approaching teams to post their architecture
+    - Working on a way to have talks that are reference architectures highlihgted more during keynote and during track (more likelihood of talks accepted)
+    - Proposed: KubeCon NA 2026 - submit two ref archtiectures. First, for Red Hatters, find bank or someone who is doing it with RHEL Image Mode and write it up. (Prefer pairup with already end user company).
+    - Bazzite: BK and Kyle - kyle works on rpm packaging at MS, and is a great presenter!
+    - Same for podman and buildah - WinBoat for Podman (https://www.winboat.app/; https://github.com/TibixDev/winboat)
+    - [name=Mohan] How does this write up work?
+        - [name=Jorge] CNCF will work with an end user - definition is partners on the landscape
+        - [name=Jorge] Also think about other users like bootcrew
+- [name=Colin] KubeCon agenda now? Or a breakout in chat actually probably
+    - Let's discuss in chat :) Avoid FOMO
+- [name=Colin] Helping mentor contributions more reliably/regularly
+    - Really feel like the 1:1 and smaller meetings are effective at getting everyone space to talk.
+    - Rotation in the channel for office hours
+    - [name=Laura] Yes, this is common :) Other projects do developer office hours.
+    - [name=Jorge] or can tack to end of this meeting
+    - [name=Colin] Maybe move this one earlier?
+- [name=Jorge] demo (have me go last)
+    - finpilot
+    - {%preview https://github.com/castrojo/finpilot %}
+
+### Shoutouts
+- [name=Jorge] Bluefin was featured in a [GitHub Universe Keynote](https://youtu.be/q1IxyisKcZI?si=zHNrlBxFkQnXLQos&t=1322) - the two people who did that last 20% are first time contributors and are now part of the greater bootc community. THANK YOU SO MUCH.
+- [name=Tulip] for https://github.com/bootc-dev/homebrew-bcvk
+- [name=Sean] Colin got podman working with codespaces!
+- [name=Jorge] bootc-image-builder new ISO support https://github.com/osbuild/bootc-image-builder/pull/1094 (still in flight)
+
+### TODO
+- [ ] Can someone add a timedate.com widget/link to the community meeting in the readme?

--- a/content/news/2025-11-07-community-meeting.md
+++ b/content/news/2025-11-07-community-meeting.md
@@ -1,0 +1,23 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 7 Nov 2025
+### Attendees
+- Colin Walters (Red Hat)
+- Mohan Shash (Red Hat)
+- John Eckersberg (Red Hat)
+- Joseph Marrero (Red Hat)
+- Jonathan Dieter (CIQ)
+- Hristo Marinov
+- Jorge Castro (CNCF)
+- Sean Thrailkill
+
+### Agenda
+- {%preview https://github.com/bootc-dev/bootc/pull/1733 %}
+- JC: https://www.yoctoproject.org/
+    - Do we know folks from this distro? discussed bootc
+- Composefs - gaining momentum now, release TBD
+- Larger/faster runners thread

--- a/content/news/2025-11-07-community-meeting.md
+++ b/content/news/2025-11-07-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-nov-07-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 7 Nov 2025
 ### Attendees

--- a/content/news/2025-11-07-community-meeting.md
+++ b/content/news/2025-11-07-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 07 Nov 2025"
+date = 2025-11-07
+slug = "2025-nov-07-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-11-14-community-meeting.md
+++ b/content/news/2025-11-14-community-meeting.md
@@ -1,0 +1,23 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 14 Nov 2025
+### Attendees
+- Colin Walters (Red Hat)
+- John Eckersberg
+- Sean Thrailkill
+- Tulip Blossom
+- Mohan Shash (RH)
+- Hristo Marinov
+
+### Agenda
+- Post KubeCon sync/updates
+  - Productive OCI meeting
+- Kairos comparison
+
+### Shoutouts
+- CNCF project team
+

--- a/content/news/2025-11-14-community-meeting.md
+++ b/content/news/2025-11-14-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-nov-14-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 14 Nov 2025
 ### Attendees

--- a/content/news/2025-11-14-community-meeting.md
+++ b/content/news/2025-11-14-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 14 Nov 2025"
+date = 2025-11-14
+slug = "2025-nov-14-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-11-21-community-meeting.md
+++ b/content/news/2025-11-21-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 21 Nov 2025"
+date = 2025-11-21
+slug = "2025-nov-21-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-11-21-community-meeting.md
+++ b/content/news/2025-11-21-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-nov-21-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 21 Nov 2025
 ### Attendees

--- a/content/news/2025-11-21-community-meeting.md
+++ b/content/news/2025-11-21-community-meeting.md
@@ -1,0 +1,24 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 21 Nov 2025
+### Attendees
+- Colin Walters
+- Laura Santamaria (Red Hat; she/her)
+- Hristo Marinov
+- Mohan Shash (RH)
+- Jonathan Dieter (CIQ)
+- Chris Kyrouac
+
+### Agenda
+- [name=Colin] Outstanding CI work
+    - For those contributing, we previously had a lot of duplication in the tests. If you're working on bootc, check {%preview https://github.com/bootc-dev/bootc/pull/1790 %}, which reworks things.
+    - You used to have to name tests 3 times. Became a merge conflict problem. Now, add single file, and we generate all the TMP stuff.
+- [name=Laura] Mohan and Laura will talk with CNCF folks about the YouTube channel; the bootc YouTube account is not "officially validated" can't upload more than 15 mins at a time. Will also be getting access to Project Control Center (sounds cool!) that allows more control over the calendar.
+- [name=Laura] US holidays next week
+    - Will put out a Slack poll on having a meeting next week
+- Open Floor!
+    - Ending early! Have a great weekend!

--- a/content/news/2025-11-28-community-meeting.md
+++ b/content/news/2025-11-28-community-meeting.md
@@ -1,0 +1,9 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 28 Nov 2025
+Cancelled because of the US holiday! Hope you have a good week!
+

--- a/content/news/2025-11-28-community-meeting.md
+++ b/content/news/2025-11-28-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-nov-28-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 28 Nov 2025
 Cancelled because of the US holiday! Hope you have a good week!

--- a/content/news/2025-11-28-community-meeting.md
+++ b/content/news/2025-11-28-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 28 Nov 2025"
+date = 2025-11-28
+slug = "2025-nov-28-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-12-05-community-meeting.md
+++ b/content/news/2025-12-05-community-meeting.md
@@ -1,0 +1,15 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## Dec 5 2025
+- Happy holidays all!
+- Reviewing https://github.com/bootc-dev/bcvk/pull/170
+- https://github.com/bootc-dev/bootc/pull/1816#discussion_r2586028936
+- Decision: Merge as is and do followup; file an issue about that
+- Open Floor
+- https://people.redhat.com/jeckersb/0001-ovl-add-directory-metadata-passthrough-feature.patch
+  - tests will go to https://github.com/amir73il/unionmount-testsuite.git
+- https://podman-desktop.io/blog is well done! We should try to blog like this and keep https://bootc-dev.github.io/news/ updated

--- a/content/news/2025-12-05-community-meeting.md
+++ b/content/news/2025-12-05-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-dec-05-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## Dec 5 2025
 - Happy holidays all!

--- a/content/news/2025-12-05-community-meeting.md
+++ b/content/news/2025-12-05-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 05 Dec 2025"
+date = 2025-12-05
+slug = "2025-dec-05-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-12-12-community-meeting.md
+++ b/content/news/2025-12-12-community-meeting.md
@@ -1,0 +1,55 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## Dec 12 2025
+### Attendees
+- Laura Santamaria (Red Hat)
+- AfterStory
+- Robert Sturla (Red Hat)
+- Hristo Marinov
+- Colin Walters
+- John Eckersberg (Red Hat, Inc.)
+- Preethi Thomas
+- Joseph Marrero Corchado (Red Hat, Inc.)
+- Dusty Mabe
+- Mohan Shash
+- Sean Thrailkill
+- Tulip Blossom
+
+### Agenda
+- [name=Colin]: more strongly enforcing review/assignment
+    - Tried the autoassign thing, but couldn't figure out how to get everything into priority queue. Hard to be consistently triaging when bot assigns PR
+    - e.g., PR 1846
+    - missed being assigned to reviews
+    - Slackbot seems overkill
+    - Maybe have a private message thing?
+    - [name=Laura] what about a weekly digest post?
+    - [name=Colin] yeah, there are options. But we need to find a good way to review.
+    - Also, 1570, what do we do with non-critical paths?
+    - Can we find a good way to efficiently prioritize
+    - [name=Joseph] a lot of the PRs have someone who already commented
+    - Do we ignore PRs if someone/a maintainer already looked at them, even if they were auto-assigned to someone?
+    - [name=Colin] Great question. Probably make sense to change the automation to reassign if a maintainer adds a review. Only need 1 person to review, so auto-assigned should get unassigned. But note that sometimes Colin ends up reviewing a lot.
+    - [name=Joseph] didn't know your workflow notified you, but it would be good to reduce load on Colin/others who review all the time. Unless deeply care about PR someone is working on, then let it go
+    - [name=Laura] Rackspace group used Zoom review, PR author has to talk through code while someone else drove screenshare. Helps onboard new contributors. This helps reduce "single person knows this code" and knowledge sharing. Would help get people more comfortable with the codebase. Laura will add a link with more info!
+        - {%preview https://gist.github.com/parlarjb/07aeb0efafde2a23fc43dfdd5be11c2e %}
+- [name=AfterStory] generic rechunker
+    - [name=Colin] The person working on it will probably be posting soon. It's a soft blocker for composefs rework. When doing images from scratch without ostree. Is a goal to make it distro agnostic, make it not specific to ostree containers. Person working on it can't be here. Will prod them to get it sooner rather than later.
+- [name=Laura] KubeCon EU stuff
+    - Deadlines coming up, and we've put in a request for a kiosk. If you're heading there and are interested it doesn't have to just be maintainers.
+    - We can also do a project lightning 🗲 talk and a ContribFest submission.
+        - ~50% attendees got All Access passes, but that means that ~50% of attendees didn't, and they're more likely to go to the lightning talks, especially in the afternoon.
+        - On ContribFests, have seen talk like building UI extension for podman desktop, OpenTelemetry how to get involved. We could do exploring bootcrew. A lot of options for this! They do give passes for this one. Submissions due Sunday!
+    - ContribFest format: dedidcated timeslots, 75-min workshops
+    - [name=Colin] what about an option of Laura being there in person but other people dialed in?
+    - RHT's OSPO can help if there's an accepted ContribFest
+    - [name=Preethi] RHT doesn't know the budget yet but suggests to submit and will do what she can from her side
+    - [name=Laura] post in the channel for the talk and we'll refine it
+- [name=Laura] will be here next week, thanks to everyone for attending. Assume last 2 fridays will be canceleld
+
+### TODO
+- [ ] Everyone to think about triaging efficiently
+

--- a/content/news/2025-12-12-community-meeting.md
+++ b/content/news/2025-12-12-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 12 Dec 2025"
+date = 2025-12-12
+slug = "2025-dec-12-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-12-12-community-meeting.md
+++ b/content/news/2025-12-12-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-dec-12-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## Dec 12 2025
 ### Attendees

--- a/content/news/2025-12-19-community-meeting.md
+++ b/content/news/2025-12-19-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-dec-19-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 19 Dec 2025
 :::info

--- a/content/news/2025-12-19-community-meeting.md
+++ b/content/news/2025-12-19-community-meeting.md
@@ -1,0 +1,21 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 19 Dec 2025
+:::info
+Our last meeting of the year :partying_face:
+:::
+
+### Attendees
+- Laura Santamaria (Red Hat)
+- Hristo Marinov
+- Joseph Marrero Corchado (Red Hat, Inc.)
+- Dusty Mabe
+
+### Agenda
+- [name=Laura] CentOS Connect random discussion
+- [name=Dusty] Quick question about a kernel regression in Fedora (off-topic, because we have space)
+- [name=Laura] Have a great holiday, folks!

--- a/content/news/2025-12-19-community-meeting.md
+++ b/content/news/2025-12-19-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 19 Dec 2025"
+date = 2025-12-19
+slug = "2025-dec-19-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2025-12-26-community-meeting.md
+++ b/content/news/2025-12-26-community-meeting.md
@@ -1,0 +1,10 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 26 Dec 2025
+:::warning
+No meeting
+:::

--- a/content/news/2025-12-26-community-meeting.md
+++ b/content/news/2025-12-26-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2025-dec-26-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 26 Dec 2025
 :::warning

--- a/content/news/2025-12-26-community-meeting.md
+++ b/content/news/2025-12-26-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 26 Dec 2025"
+date = 2025-12-26
+slug = "2025-dec-26-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-01-02-community-meeting.md
+++ b/content/news/2026-01-02-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 02 Jan 2026"
+date = 2026-01-02
+slug = "2026-jan-02-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-01-02-community-meeting.md
+++ b/content/news/2026-01-02-community-meeting.md
@@ -1,0 +1,10 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 2 Jan 2026
+:::warning
+No meeting
+:::

--- a/content/news/2026-01-02-community-meeting.md
+++ b/content/news/2026-01-02-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-jan-02-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 2 Jan 2026
 :::warning

--- a/content/news/2026-01-09-community-meeting.md
+++ b/content/news/2026-01-09-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-jan-09-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 9 Jan 2026
 ### Attendees

--- a/content/news/2026-01-09-community-meeting.md
+++ b/content/news/2026-01-09-community-meeting.md
@@ -1,0 +1,31 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 9 Jan 2026
+### Attendees
+
+- Colin Walters
+- Laura Santamaria
+- Hristo Marinov
+- Chris Kyrouac
+- Robert Sturla
+- Sean Thrailkill
+
+### Agenda
+- Happy New Years all!
+- [name=Colin] CI changes ongoing
+    - multiple git repos in the org
+    - Syncing GHA was overkill and a lot, so now a shared actions repo!
+    - There's obviously a lot of work that can be picked up here :)
+- [name=Laura] Dogs!
+- [name=Colin] PR review backlog
+    - Someone new doing composefs work!
+    - If something got missed, feel free to raise it here.
+    - If there's something you need mentorship on, you can bring it up here, too.
+- [name=Sean] In composefs matrix group. Is there a better place to get release updates?
+    - Follow composefs repo?
+    - [name=Colin] yes. Probably makes sense to do release there soon as bigger changes. One thing that just happened there was fixing reverse dependency API (making sure things are in sync). Will try to do a better job of releases there.
+    - Fixing last ergonomic things around garbage collection etc. Looking forward to accelerating soon.

--- a/content/news/2026-01-09-community-meeting.md
+++ b/content/news/2026-01-09-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 09 Jan 2026"
+date = 2026-01-09
+slug = "2026-jan-09-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-01-16-community-meeting.md
+++ b/content/news/2026-01-16-community-meeting.md
@@ -1,0 +1,56 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 16 Jan 2026
+[Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1768577400000/summaries?password=763143f2-7c8e-4e2c-81ca-5966f0c6ba0c)
+
+### Attendees
+- Colin Walters
+- Laura Santamaria (Red Hat; she/her)
+- Joseph Marrero Corchado (Red Hat)
+- John Eckersberg (Red Hat)
+- Chris Kyrouac
+- Jonathan Dieter | CIQ
+- Sean Thrailkill
+- Mohan Shash
+- Dusty
+- Preethi Thomas
+
+### Agenda
+- [name=Colin] Review pending release notes in https://github.com/bootc-dev/bootc/releases/edit/untagged-cd5086ebeadb8bb2bcfb and release ceremony
+    - Colin showing the draft
+    - General format: Taking autogen release notes, tweaking it and adjusting with an AI agent. Features, bugfixes, and other changes.
+    - Now everyone reads!
+    - [name=Joseph] Making sure ostree fix is in
+    - [name=Colin] A lot has happened in the composefs side. A lot pending, so roll into next release.
+    - [name=John] Since patch release, should we have branched from 1.12 tag with just bug fixes?
+        - [name=Colin] Could do that, but no procedure for that right now b/c tag is branch is release.
+        - [name=John] Something to consdier/asipre for
+            - [name=Colin] Could consider that with sufficient automation. Discuss as wider group. People want the newer features, too, though; everyone wants the features without the bugs :sweat_smile: 
+    - Let's do the release! Aaaaand done
+- [name=Laura] kubevirt+bootc (https://groups.google.com/g/kubevirt-dev/c/K-jNJL_Y9bA/m/ZTH78OqFBAAJ ) also https://github.com/bootc-dev/bcvk/issues/22
+    - [name=Colin] The thing to connect with is asking what is the podman and rhel 9.6 do in this situation... bcvk ephemeral is so nice. Nice to spin up as if vm but not actually vm. Connection with kubevirt side is... Meme about cattle vs pets, but argues that not true in actuality. Kubevirt side; would make total sense to expose model of ephemeral - mount container's root but use it running kernel in the container but ... kata containers... Laura got lost :p
+    - [name=Laura] Interesting idea, also relates to kairos.io which is in CNCF. (Like KubeVirt which is CNCF (incubating)). We should try to build more cross-collaboration with others in the org.
+    - [name=Laura] Congrats for accepted ContribFest! If you're going to KubeCon EU let's make sure it works! This is a prime spot right before lunch when folks are excited (and available?) We should be ready to help people at that time.
+    - [name=Laura] Kiosk is approved (prime spot!)
+    - [name=Joseph] Lighting talk is accepted too!
+    - [name=Laura] Now we need to write the talks! Let's collab in Slack calling out Sean!
+- [name=Laura] Fedora (Atomic) "midstream" initiative is accepted!
+- [name=Colin] Lots of groups working in various spots. e.g., Image Builder team midstream/downstream, and e.g. Fedora CoreOS. Consider consolidating :) There's a lot of things that are moving parts.
+- [name=Laura] Agree lots of interesting things happening thing there! Should be enabling drive-by contributions. Also need to think about bootkrew and Bazzite e.g. and help we're enabling them but also ensuring their work is generalized.
+- [name=Laura] As we chat with Kairos etc. should think about how this applies to moving to Incubuation which should be a strong possibility. Should keep this in mind!
+- [name=Colin] Vaguely thinking about inviting other folks to work on repos and ensuring that works well
+- [name=Laura] Should have a contributor ladder, clear guidelines on maintainer/reviewer promotions. And everyone should fall under the same ladder. Consider an OWNERS/CODEOWNERS style model that helps add people to review rotation. Any folks interested can join that conversation around how the ladder looks! Or we can move slowly. Beginning of the year so we're still gaining speed.
+- [name=Colin] likes the Rust bors @delegate approach (edit; https://github.com/bootc-dev/infra/issues/83)
+- [name=Laura] can add people lightweight temporarily - we want to enable drive-by contribution, but also convert drive-by to a more regular contributor.
+- [name=Laura] Zoom code reviews and group invite - helps everyone learn and how to contribute. Can do this for ContribFest too!
+- [name=Laura] Time to end!
+
+### Shoutouts
+- All the people who worked on KubeCon EU proposals
+
+### TODO
+- [ ] Laura to drop docs

--- a/content/news/2026-01-16-community-meeting.md
+++ b/content/news/2026-01-16-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-jan-16-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 16 Jan 2026
 [Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1768577400000/summaries?password=763143f2-7c8e-4e2c-81ca-5966f0c6ba0c)

--- a/content/news/2026-01-16-community-meeting.md
+++ b/content/news/2026-01-16-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 16 Jan 2026"
+date = 2026-01-16
+slug = "2026-jan-16-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-01-23-community-meeting.md
+++ b/content/news/2026-01-23-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 23 Jan 2026"
+date = 2026-01-23
+slug = "2026-jan-23-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-01-23-community-meeting.md
+++ b/content/news/2026-01-23-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-jan-23-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 23 Jan 2026
 [Zoom Summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1769182200000/summaries?password=6a248ea5-6a5d-4433-a7b1-cd97d5aa4f86)

--- a/content/news/2026-01-23-community-meeting.md
+++ b/content/news/2026-01-23-community-meeting.md
@@ -1,0 +1,62 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 23 Jan 2026
+[Zoom Summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1769182200000/summaries?password=6a248ea5-6a5d-4433-a7b1-cd97d5aa4f86)
+
+### Attendees
+- Colin Walters
+- Laura Santamaria (she/her; Red Hat)
+- Hristo Marinov
+- Chris Kyrouac
+- John Eckersberg (Red Hat, Inc.)
+- Mohan Shash
+- Dusty
+- Jonathan Lebon
+
+### Agenda
+- [name=Laura] Snow in the US! Texas is losing their minds!
+- [name=Laura] Welcome!
+- [name=Mohan] Zoom summary should be posted
+- [name=John] Composability of package sets
+    - Chunkah! Baby steps :)
+    - If we have package sets like A-Z, and we want to compose them in any sort of permutation without blowing your network transfer, how could we go about doing that? Problem that has come up; something to chew on.
+    - Stitching the rpm layer later?
+    - [name=colin, in chat] https://grahamc.com/blog/nix-and-layered-docker-images/ ?
+    - [name=Jonathan] Been thinking in this area with chunker work. Needs more context on what exactly the problem is. Is there a link with details?
+    - [name=John] No link. Still working on it. If fleet of hosts with different package sets, overlap of packages. End up with distinct sets. How to proliferate with distinct container builds (which blows out storage with duplicated package data)
+    - [name=Jonathan] Is this image mode or also apt container images?
+    - [name=John] w/in bootc
+    - [name=Jonathan] most optimal strategy is no combining at all. More possible for apt containers. e.g., Hummingbird. Some have 20 rpm; can get perfect de-dup, but gets trickier for apt containers beyond a certain size. Rare to have minimal set to fit within constraints of containers image (500 layers is arbitrary limit). One Silverblue - ~900 rpms. So need a strategy. Also layers can be too many to manage. If history of updates, can look at analysis of optimal way of grouping. Kinda like with `chunkah`. Pre-compute different versions of packaging that we could have done in the past... will get complicated, wouldn't recommend. Try to spread out as much as possible.
+    - [name=John] May be just rolling bulk into one layer... could be problem. How close do you come close to overlay limit.
+    - [name=Jonathan] Not close to limit for kernel; hit container runtime limit first.
+    - [name=John] Container build where segmented and de-dup'd layers. Different rpm database layers at the end...
+    - [name=Jonathan] RpmDatabase unstable and will always change.
+    - [name=Dusty] Hardcoded limit. Can't go above that. If no history (or too complicated to look at) could we chunk smaller things together? Large grouped by srpm, then small things on kb level, group together. Will change a lot, but could avoid problems.
+    - [name=Jonathan] Will link to what `chunkah` does. Used the rpm changelog to figure out measure of stability of a package. Stability and size relates to packaging. https://github.com/jlebon/chunkah/blob/main/src/packing.rs
+    - [name=Dusty] Stable is how often changes, not quality of software
+    - [name=Colin] Original rpmtree debated this a lot. NixOS blog is really useful to read. Keeping it simpler is good. For bootable images, it's easy 30% of size just on its own.
+    - [name=Jonathan] The linked algorithm finds out those things on its own. Emerging behaviors from algorithm like this.
+    - [name=Dusty] Chunking stuff we use today is built into bootc?
+    - [name=Colin] The rust code is in bootc, logically exposed through rpm-ostree
+    - [name=Dusty] But already in the base image, right? So when doing container build, it's a second step (chunking code). For `chunkah` specifically, not already in base image. Should we try to replace the old chunking code with new chunking code so it's just there versus conscious decision to just use it?
+    - [name=Jonathan] Definitely planning to package. It's another input to the container image that they have to track. Would be nice in builder image used in pipelines like Konflux. Haven't really gotten to this part yet :smile: Chunkah - not just about bootc, works with apt containers
+    - [name=John] Like having it as a separate thing. Colin did the sealed building thing. Tools needed at build time but don't want to include in image. Might be a good spot for `chunkah`. Don't want `chunkah` installed on final system.
+    - [name=Dusty] That's where the current chunking code wins out. Could remain separate and pull in as library. Could be an option; avoids decision for end user.
+    - [name=John] Accumulating list of container build time things. So not difficult to add to list.
+    - [name=Colin] write up a productization plan for `chunkah`. Should help a lot.
+    - [name=Jonathan] Maybe move to containers org.
+    - [name=Colin] Does
+- [name=Laura] FYI, SCaLE talk/Fedora Hatch
+- one PR to bootc base images related to a packaging change in Fedora: https://gitlab.com/fedora/bootc/base-images/-/merge_requests/350
+
+### Shoutouts
+- :tada: Pragyan for lots of test fixes! :tada:
+- :tada: Jonathan for `chunkah` :tada:
+
+### TODO
+- [ ] Laura to ask the projects team about org and repo
+

--- a/content/news/2026-01-30-community-meeting.md
+++ b/content/news/2026-01-30-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-jan-30-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 30 Jan 2026
 [Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1769787000000/summaries?password=b7524b79-afec-44f3-a19c-cd5f9081d54e)

--- a/content/news/2026-01-30-community-meeting.md
+++ b/content/news/2026-01-30-community-meeting.md
@@ -1,0 +1,33 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 30 Jan 2026
+[Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1769787000000/summaries?password=b7524b79-afec-44f3-a19c-cd5f9081d54e)
+
+### Attendees
+- Colin Walters
+- John Eckersberg (Red Hat LLC)
+- Laura Santamaria (she/her; Red Hat LLC)
+- Hristo Marinov
+- Anish Bhatt (Salesforce. com, Inc.)
+- Jonathan Lebon
+- Mohan Shash (RH)
+- Sean Thrailkill
+
+### Agenda
+[Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1769787000000/summaries?password=b7524b79-afec-44f3-a19c-cd5f9081d54e)
+
+- Meeting time reshuffling?
+- [name=Laura] Contributor ladder and committees.
+    - Bootc Project Control Center: https://projectadmin.lfx.linuxfoundation.org/project/lfRze8DsMRJ0EnMnuo
+- [name=Laura] Will post and can click on links
+- [name=Laura] shows the PCC
+- [name=Colin] Talking about access
+- [name=Jonathan] chunkah update!
+
+### Shoutouts
+- [name=Colin] Allison for reviewing lots of composefs work!
+- [name=Anish] bootc+[kured](https://kured.dev/) works super well

--- a/content/news/2026-01-30-community-meeting.md
+++ b/content/news/2026-01-30-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 30 Jan 2026"
+date = 2026-01-30
+slug = "2026-jan-30-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-02-06-community-meeting.md
+++ b/content/news/2026-02-06-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-feb-06-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 06 Feb 2026
 [Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1770391800000/summaries?password=cc5e77d7-e34a-4b74-9033-c4f1f38bcd99)

--- a/content/news/2026-02-06-community-meeting.md
+++ b/content/news/2026-02-06-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 06 Feb 2026"
+date = 2026-02-06
+slug = "2026-feb-06-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-02-06-community-meeting.md
+++ b/content/news/2026-02-06-community-meeting.md
@@ -1,0 +1,45 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 06 Feb 2026
+[Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1770391800000/summaries?password=cc5e77d7-e34a-4b74-9033-c4f1f38bcd99)
+
+### Attendees
+- Laura Santamaria (Red Hat)
+- Sunny Fugate
+- Hristo Marinov
+- Preethi Thomas (Red Hat LLC)
+- Joseph Marrero Corchado (Red Hat)
+- Jonathan Lebon
+- Anish Bhatt (Salesforce.com, Inc.)
+- Colin Walters
+- John Eckersberg
+- Dusty Mabe
+
+### Agenda
+- [name=Joseph] Talk at CentOS Connect - FOSDEM Fringe [YouTube video](https://www.youtube.com/live/CNOGKUTYhng?t=11008s)
+- [name=Colin] {%preview https://github.com/containers/composefs-rs/pull/224 %} will do a deeper dive on Monday
+- [name=Laura] Calendar updates
+    - Dev/Engineering Sync on Mondays and Wednesdays: [bootc project calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/bootc)
+- [name=Colin] CI fixed up
+- [name=JL] chunkah update!
+    - {%preview https://github.com/jlebon/chunkah/pull/34%}
+    - [name=Joseph] Is this added to the CoreOS CI yet?
+        - [name=JL] Not yet. Convincing it's working and analyzing it. Need to make CI better first. Big gap: One principle of chunkah is not touching the rootfs, and there's no real CI for that (no CI that does a rootfs diff).
+        - [name=Colin] Why harder to mount? (Answer: Not in CI yet) This could be trivial in the bootc CI.
+        - [name=JL] Where would we do this? Upstream bootc CI setup?
+        - [name=Colin] yep! Used to just build a binary, but got burned by that because previous container image had state leakage. Had to switch to always building an RPM... Then we do a from-scratch build as an override. So single layer. Should be able to toss chunkah in there!
+        - Justfile as entrypoint
+- [name=Anish] Is there a good place to read up on chunking?
+        - [name=John] This is a good place to read up on the current state with rpm-ostree: {%preview https://docs.fedoraproject.org/en-US/bootc/building-from-scratch/#_optimizing_container_images %}
+        - [name=JL] For the newer way that goes past rpm-ostree, read the chunkah readme: {%preview https://github.com/jlebon/chunkah %}
+- [name=Laura] Shoutout time :)
+    - [name=Dusty] regarding the review request and packaging reviews, could use some AI rubbed on it :D
+- [name=Laura] Welcome to new folks!
+
+### Shoutouts
+- @jeckersb for reviewing chunkah Review Request!
+- @joseph for the FOSDEM talk!

--- a/content/news/2026-02-13-community-meeting.md
+++ b/content/news/2026-02-13-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 13 Feb 2026"
+date = 2026-02-13
+slug = "2026-feb-13-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-02-13-community-meeting.md
+++ b/content/news/2026-02-13-community-meeting.md
@@ -1,0 +1,45 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 13 Feb 2026
+[Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1770996600000/summaries?password=6752942e-2973-46c7-b306-af3b819dc939)
+
+### Attendees
+- Colin Walters
+- Laura Santamaria (Red Hat)
+- John Eckersberg (Red Hat LLC)
+- Preethi Thomas (Red Hat LLC)
+- Jonathan Lebon
+- Mohan Shash
+- Hristo Marinov
+- Dusty Mabe
+
+### Agenda
+- [name=Colin] {%preview https://github.com/bootc-dev/bootc/discussions/2007 %}
+    - New project announced! bootc manager :D
+    - replace and extend podman-bootc (attempting to streamline cross-platform)
+    - We could add this to a list of tools as an option.
+    - Tension: Defaults to bootc-image-builder (Fedora specific, not quite part of CNCF...).
+    - Could reference as a community tool.
+    - How do we want to pull in tools like this?
+    - Podman Desktop is cool and lots going on there, but we do want a CLI with an API that the GUI can call :D
+    - [name=Laura] This sounds cool! How about an awesome list?
+    - [name=John] Maybe a subsection of adopters?
+    - [name=Jonathan] Likes awesome list idea
+- [name=Laura] Engineering sync checkin
+    - [name=Colin] Can't log in to get recordings
+    - [name=John] it's going well, but no non-redhat people yet. Increased frequency of non-US people has been a bonus!
+    - [name=Laura] It takes time. This all might be really early
+- [name=John] We have an internal afternoon-us time one. What about opening that up to public?
+    - [name=Colin] yeah I think my vote is change Wednesday to afternoon EST
+    - [name=John] two days per week is nice, though. We could change the tues/thurs to public?
+- [name=Jonathan] Should bootc-man call out to <something></something>
+    - {%preview https://github.com/tnk4on/bootc-man/issues/1#issuecomment-3894326508 %}
+- [name=Jonathan] Chunkah contributor adding Arch support
+
+### Shoutouts
+- [name=Laura] tnk4on for making bootc-man
+- [name=Jonathan] Chunkah contributor adding Arch support

--- a/content/news/2026-02-13-community-meeting.md
+++ b/content/news/2026-02-13-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-feb-13-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 13 Feb 2026
 [Zoom summary](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093-1770996600000/summaries?password=6752942e-2973-46c7-b306-af3b819dc939)

--- a/content/news/2026-02-20-community-meeting.md
+++ b/content/news/2026-02-20-community-meeting.md
@@ -1,0 +1,11 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 20 Feb 2026
+:::warning
+No meeting
+:::
+

--- a/content/news/2026-02-20-community-meeting.md
+++ b/content/news/2026-02-20-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-feb-20-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 20 Feb 2026
 :::warning

--- a/content/news/2026-02-20-community-meeting.md
+++ b/content/news/2026-02-20-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 20 Feb 2026"
+date = 2026-02-20
+slug = "2026-feb-20-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-02-27-community-meeting.md
+++ b/content/news/2026-02-27-community-meeting.md
@@ -1,0 +1,40 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 27 Feb 2026
+### Attendees
+- Colin Walters (Red Hat; he/him)
+- Laura Santamaria (Red Hat; she/her)
+- Hristo Marinov
+- Max Haack (Caligra)
+- Joseph Marrero Corchado (Red Hat LLC)
+- Chris Kyrouac (Red Hat LLC)
+- Sean Thrailkill
+- Dusty Mabe (Red Hat)
+- Mohan Shash
+
+### Agenda
+- [name=Joseph] Community - enablement for various distros
+    - should we bring bootcrew into bootc? https://github.com/bootcrew
+    - https://github.com/bootc-dev/bootc/issues/1770 (and test in CI)
+    - We had CoreOS layering examples back in the day.
+    - Would it make sense to have a similar repo with recipes or examples?
+    - In mind: Monorepo with community enabled/community maintained examples
+    - [name=Colin] Would be great for the bundled dep release packages for other distributions
+        - Need to be careful about the CNCF work and separation. Will people expect support/CVE addressing
+    - [name=Colin] OS thing... how do we encourage sharing of examples?
+    - [name=Laura] Awesome lists and Discussions board
+    - [name=Joseph] Any of those could work
+    - [name=Sean] Like the idea of Discussions. People are already putting it on an issue. Why not have an official place for that?
+    - [name=Colin] this relates to https://github.com/bootc-dev/infra/issues/18
+- [name=Laura] Welcome new people!
+    - Max joins us :)
+    - Adopter file!
+    - [name=Colin] Any thoughts about adoption?
+        - [name=Max] It just works!
+- [name=Laura] Contribution ladder 🪜
+### Shoutouts
+- :tada: Tulip has done a great job with bootcrew! :tada:

--- a/content/news/2026-02-27-community-meeting.md
+++ b/content/news/2026-02-27-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 27 Feb 2026"
+date = 2026-02-27
+slug = "2026-feb-27-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-02-27-community-meeting.md
+++ b/content/news/2026-02-27-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-feb-27-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 27 Feb 2026
 ### Attendees

--- a/content/news/2026-03-06-community-meeting.md
+++ b/content/news/2026-03-06-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 06 Mar 2026"
+date = 2026-03-06
+slug = "2026-mar-06-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-03-06-community-meeting.md
+++ b/content/news/2026-03-06-community-meeting.md
@@ -1,0 +1,17 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 6 Mar 2026
+### Attendees
+- Colin Walters
+- John Eckersberg
+- Mohan Shash (RH)
+- Prasanth
+- Joseph Marrero (RH)
+
+### Agenda
+- [name=Colin] https://github.com/composefs/composefs-rs/pull/224
+- [name=Prasanth] Discussion on Edge Registry -  - Possiblities ??

--- a/content/news/2026-03-06-community-meeting.md
+++ b/content/news/2026-03-06-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-mar-06-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 6 Mar 2026
 ### Attendees

--- a/content/news/2026-03-13-community-meeting.md
+++ b/content/news/2026-03-13-community-meeting.md
@@ -1,0 +1,42 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 13 March 2026
+### Attendees
+- Colin Walters
+- John Eckersberg
+- Laura Santamaria
+- Sean Thrailkill
+- Chris Kyrouac
+- Joeseph Marrero Corchado
+- Mohan Shash
+- Prasanth Baskar (8gears AG)
+- Anish Bhatt (Salesforce.com, Inc.)
+- Preethi Thomas
+
+### Agenda
+- {%preview https://github.com/bootc-dev/infra/pull/137 %}
+    - [name=Colin] Trying to describe the desired state. CI is really hard to deal with. The aspirational goal <-- described here. Please read!
+    - [name=John] Motivation +1, really need to get everything set up and standardized and DOCUMENTED is really nice
+    - [name=Colin] some things were missing renovate, for example
+- [name=Colin] Adding bootcrew to linked infra
+    - Would love to include in orbit, so in composefs we use the debian bootcrew image in integration testing. So debian bootcrew needs to be maintained for the project. Did a PR to sync renovate config in composefs org.
+    - Would like to file an issue.
+    - Bring gating on bootcrew images into the main bootc dev CI. Will expand matrix.
+- [name=Laura] Summary of SCALE talk, demoed switching between Atomic Desktops (w/rpm-ostree). Well received.
+- [name=Laura] Justin Garrison gave state of immutable talk (compared ostree vs other toolchains) - more neutral vs positive. Disagreed with some technical decisions but he is running a bootc system. (TODO find links to talk here)
+- [name=Laura] A lot of potential new users asking questions, Laura also brought a ublue Aurora
+- [name=Laura] Josh Berkus also did a talk on custom images and installing on bare metal. Anaconda workflow could be improved
+- [name=Prasanth] Arch bootcrew expanding on memory and in storage on memory. Thoughts?
+    - [name=Prasanth] Using gitlab private workflows with a bootc image (base k3s distro for test pipeline). Takes too much storage. Anything they can do?
+    - Will be at KubeCon and can talk about it.
+    - Registry server or per device?
+        - Image gets bigger because adding more packages over time. Eating the registry's s3 bucket storage
+        - There's no one solution to this. But, there's Chunkah! https://github.com/jlebon/chunkah. Best practice is to try to split out large layers into their own isolated things to avoid cascading changes. Avoid bundling configs with packages. Chunkah will resplit everything up and canonicalize it.
+        - [name=John] Also, you're likely using the composefs backend. Until very recently, it didn't have garbage collection. But as of the release this week, it has garbage collection! So try updating bootc and composefs and see if it cleans everything up
+
+### TODO
+- [ ] Reach out to Tulip on Slack <-- Colin

--- a/content/news/2026-03-13-community-meeting.md
+++ b/content/news/2026-03-13-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-mar-13-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 13 March 2026
 ### Attendees

--- a/content/news/2026-03-13-community-meeting.md
+++ b/content/news/2026-03-13-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 13 Mar 2026"
+date = 2026-03-13
+slug = "2026-mar-13-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-03-20-community-meeting.md
+++ b/content/news/2026-03-20-community-meeting.md
@@ -1,3 +1,9 @@
++++
+title = "Bootc Community Meeting Notes - 20 Mar 2026"
+date = 2026-03-20
+slug = "2026-mar-20-community-meeting"
++++
+
 # bootc community meeting
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)

--- a/content/news/2026-03-20-community-meeting.md
+++ b/content/news/2026-03-20-community-meeting.md
@@ -1,0 +1,33 @@
+# bootc community meeting
+
+[Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
+
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+
+## 20 March 2026
+### Attendees
+- John Eckersberg
+- Sean Thrailkill
+- Joeseph Marrero Corchado
+- Hristo Marinov
+- Anish Bhatt
+- Colin Walters
+
+### Agenda
+
+- https://github.com/bootc-dev/bootc/pull/2071
+    - [name=Colin] Do we hold on merging this until we determine the correct scope for testing transient root?
+    - [name=John] Not for a bug fix, which is the purpose of this MR
+    - MR was merged by Colin!
+- Discussion of testing: Expanding the matrix: unified storage
+- Agreement to extend more testing in postsubmit and also gate for releases
+- Debugging https://bodhi.fedoraproject.org/updates/FEDORA-2026-cfa95147df
+- https://github.com/containers/skopeo/pull/2714
+    - We have `--enforce-container-sigpolicy` for `bootc switch` that would have to be updated to support this work
+    - Do we create a Bootc config file where users could specify that? Don't want to recreate in file form what we already do for `podman` command
+    - OCI Sealing enforces signature and everything else we want
+    - There are some edge cases that need to be considered but this seems feasible
+
+### Shoutouts!
+- Giuseppe is working on unified storage related things!
+- Ublue and secureblue!

--- a/content/news/2026-03-20-community-meeting.md
+++ b/content/news/2026-03-20-community-meeting.md
@@ -8,7 +8,7 @@ slug = "2026-mar-20-community-meeting"
 
 [Meeting Link/info](https://zoom-lfx.platform.linuxfoundation.org/meeting/96540875093?password=7889708d-c520-4565-90d3-ce9e253a1f65)
 
-Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#code-of-conduct) applies.
+Feel free to add yourself to the attendee list and to add to the agenda! This is an open community meeting, and our [Code of Conduct](https://github.com/bootc-dev/bootc?tab=readme-ov-file#user-content-code-of-conduct) applies.
 
 ## 20 March 2026
 ### Attendees


### PR DESCRIPTION
KubeCon EU `bootc` contribfest contribution: split & move meeting notes from `hackmd.io/@cgwalters/HJk3Aj0ree/edit` to `bootc-dev.github.io/news`. Also did additional cleanup & making all the meeting notes consistent. CC: @nimbinatus nimbinatus