### PR TITLE
fix: add CNAME file and update base_url for bootc.dev custom domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://bootc-dev.github.io"
+base_url = "https://bootc.dev"
 #base_url = "http://localhost"
 theme = "juice"
 title = "bootc"

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+bootc.dev


### PR DESCRIPTION
The CNAME file was missing from the deployed gh-pages branch, causing
GitHub Pages to disassociate the custom domain. Adding it to static/
ensures it persists across deploys. Also update base_url to match.

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
